### PR TITLE
Store JIRA status ID instead of status text

### DIFF
--- a/ignite-tc-helper-web/src/main/java/org/apache/ignite/ci/tcbot/visa/TcBotTriggerAndSignOffService.java
+++ b/ignite-tc-helper-web/src/main/java/org/apache/ignite/ci/tcbot/visa/TcBotTriggerAndSignOffService.java
@@ -60,6 +60,7 @@ import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.T2;
 import org.apache.ignite.jiraignited.IJiraIgnited;
 import org.apache.ignite.jiraignited.IJiraIgnitedProvider;
+import org.apache.ignite.jiraservice.JiraTicketStatusCode;
 import org.apache.ignite.jiraservice.Ticket;
 import org.apache.ignite.tcbot.common.conf.IGitHubConfig;
 import org.apache.ignite.tcbot.common.conf.IJiraServerConfig;
@@ -246,7 +247,7 @@ public class TcBotTriggerAndSignOffService {
                 String muteTicket = mute.assignment.text.substring(pos + browseUrl.length());
 
                 if (ticket.key.equals(muteTicket)) {
-                    mute.ticketStatus = ticket.status();
+                    mute.ticketStatus = JiraTicketStatusCode.text(ticket.status());
 
                     break;
                 }
@@ -444,7 +445,7 @@ public class TcBotTriggerAndSignOffService {
                 }
 
                 c.jiraIssueId = ticket == null ? null : ticket.key;
-                c.jiraStatusName = ticket == null ? null : ticket.status();
+                c.jiraStatusName = ticket == null ? null : JiraTicketStatusCode.text(ticket.status());
 
                 if (!Strings.isNullOrEmpty(c.jiraIssueId)
                         && jiraCfg.getUrl() != null)
@@ -462,7 +463,9 @@ public class TcBotTriggerAndSignOffService {
 
         List<String> branches = gitHubConnIgnited.getBranches();
 
-        List<Ticket> activeTickets = tickets.stream().filter(Ticket::isActiveContribution).collect(Collectors.toList());
+        List<Ticket> activeTickets = tickets.stream()
+            .filter(ticket -> JiraTicketStatusCode.isActiveContribution(ticket.status()))
+            .collect(Collectors.toList());
 
         activeTickets.forEach(ticket -> {
             String branch = ticketMatcher.resolveTcBranchForPrLess(ticket,
@@ -480,7 +483,7 @@ public class TcBotTriggerAndSignOffService {
             ContributionToCheck contribution = new ContributionToCheck();
 
             contribution.jiraIssueId = ticket.key;
-            contribution.jiraStatusName = ticket.status();
+            contribution.jiraStatusName = JiraTicketStatusCode.text(ticket.status());
             contribution.jiraIssueUrl = jiraIntegration.generateTicketUrl(ticket.key);
             contribution.tcBranchName = branch;
 

--- a/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/Jira.java
+++ b/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/Jira.java
@@ -19,6 +19,7 @@ package org.apache.ignite.jiraservice;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.ignite.tcbot.common.conf.IDataSourcesConfigSupplier;
 import org.apache.ignite.tcbot.common.interceptor.AutoProfiling;
 import org.apache.ignite.tcbot.common.conf.IJiraServerConfig;
@@ -53,7 +54,9 @@ class Jira implements IJiraIntegration {
     /** {@inheritDoc} */
     @Override public Tickets getTicketsPage(String url) {
         try {
-            return new Gson().fromJson(sendGetToJira(url), Tickets.class);
+            Gson gson = new GsonBuilder().registerTypeAdapterFactory(new ReadResolveFactory()).create();
+
+            return gson.fromJson(sendGetToJira(url), Tickets.class);
         }
         catch (Exception e) {
             String errMsg = "Exception happened during receiving JIRA tickets " +

--- a/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/JiraTicketStatusCode.java
+++ b/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/JiraTicketStatusCode.java
@@ -1,0 +1,71 @@
+package org.apache.ignite.jiraservice;
+
+/**
+ * Enumerates well-known JIRA issue statuses and its internal IDs.
+ */
+public enum JiraTicketStatusCode {
+    OPEN(1, "Open"),
+    IN_PROGRESS(3, "In Progress"),
+    REOPENED(4, "Reopened"),
+    RESOLVED(5, "Resolved"),
+    CLOSED(6, "Closed"),
+    BACKLOG(10010, "Backlog"),
+    PATCH_AVAILABLE(10012, "Patch Available"),
+    PENDING(10402, "Pending"),
+    PATCH_REVIEWED(10800, "Patch Reviewed");
+
+    JiraTicketStatusCode(int id, String name) {
+       this.id = id;
+       this.name = name;
+    }
+
+    private final int id;
+
+    private final String name;
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param id Status ID.
+     * @return Resolved status or <code>null</code> if status not found.
+     */
+    public static JiraTicketStatusCode fromId(int id) {
+        for (JiraTicketStatusCode code : values()) {
+            if (code.id == id)
+                return code;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Text representation of given status code.
+     */
+    public static String text(JiraTicketStatusCode statusCode) {
+        if (statusCode == null)
+            return "<unknown>";
+
+        return statusCode.getName();
+    }
+
+    /**
+     * Checks if ticket relates to some Active (In progress/Patch Available) Contribution.
+     */
+    public static boolean isActiveContribution(JiraTicketStatusCode statusCode) {
+        if (statusCode == null)
+            return false;
+
+        return JiraTicketStatusCode.PATCH_AVAILABLE == statusCode ||
+            JiraTicketStatusCode.IN_PROGRESS == statusCode ||
+            JiraTicketStatusCode.OPEN == statusCode ||
+            JiraTicketStatusCode.BACKLOG == statusCode ||
+            JiraTicketStatusCode.REOPENED == statusCode ||
+            JiraTicketStatusCode.PATCH_REVIEWED == statusCode;
+    }
+}

--- a/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/JiraTicketStatusCode.java
+++ b/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/JiraTicketStatusCode.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ignite.jiraservice;
 
 /**

--- a/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/ReadResolveFactory.java
+++ b/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/ReadResolveFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ignite.jiraservice;
 
 import com.google.gson.Gson;

--- a/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/ReadResolveFactory.java
+++ b/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/ReadResolveFactory.java
@@ -1,0 +1,36 @@
+package org.apache.ignite.jiraservice;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+/**
+ * Type adapter factory which is intended to trigger readResolve() after Gson deserialization.
+ */
+public class ReadResolveFactory implements TypeAdapterFactory {
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+
+        return new TypeAdapter<T>() {
+            public void write(JsonWriter out, T value) throws IOException {
+                delegate.write(out, value);
+            }
+
+            public T read(JsonReader in) throws IOException {
+                T obj = delegate.read(in);
+
+                if (obj instanceof Status)
+                    ((Status)obj).readResolve();
+                // Add more classes for post-processing if necessary.
+
+                return obj;
+            }
+        };
+    }
+}

--- a/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/Status.java
+++ b/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/Status.java
@@ -17,39 +17,44 @@
 
 package org.apache.ignite.jiraservice;
 
+import java.io.ObjectStreamException;
+
 /**
  * Status for Jira ticket.
- *
- * "Closed" "Open" "Backlog" "Resolved" "In Progress" "Pending" "Patch Available" "Reopened" "Patch Reviewed"
  */
 public class Status {
-    /** Open status name. */
-    public static final String OPEN_NAME = "Open";
-
-    /** Reopened status name. */
-    public static final String REOPENED_NAME = "Reopened";
-
-    /** Backlog status name. */
-    public static final String BACKLOG_NAME = "Backlog";
-
-    /** Patch Available status name. */
-    public static final String PA_NAME = "Patch Available";
-
-    /** In Progress status name. */
-    public static final String IP_NAME = "In Progress";
-
     /** Status text (open, resolved, etc). */
     public String name;
 
+    /** Internal JIRA status ID. */
+    public int id;
+
+    /** Resolved well-known status code. */
+    public JiraTicketStatusCode statusCode;
+
     /**
-     * @param name Name.
+     * @param id JIRA status ID.
      */
-    public Status(String name) {
-        this.name = name;
+    public Status(int id) {
+        this.id = id;
+
+        try {
+            readResolve();
+        } catch (ObjectStreamException e) {
+            // Should be never thrown.
+        }
     }
 
-    /** {@inheritDoc} */
-    @Override public String toString() {
-        return name;
+    /**
+     * Reconstructs object on unmarshalling.
+     *
+     * @return Reconstructed object.
+     * @throws ObjectStreamException Thrown in case of unmarshalling error.
+     */
+    protected Object readResolve() throws ObjectStreamException {
+        statusCode = JiraTicketStatusCode.fromId(id);
+        name = JiraTicketStatusCode.text(statusCode);
+
+        return this;
     }
 }

--- a/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/Ticket.java
+++ b/tcbot-jira/src/main/java/org/apache/ignite/jiraservice/Ticket.java
@@ -56,11 +56,11 @@ public class Ticket {
      * @return Ticket status (open, resolved, etc);
      */
     @Nullable
-    public String status() {
+    public JiraTicketStatusCode status() {
         if (fields == null || fields.status == null)
             return null;
 
-        return fields.status.name;
+        return fields.status.statusCode;
     }
 
     /** {@inheritDoc} */
@@ -70,18 +70,5 @@ public class Ticket {
             .add("key", key)
             .add("fields", fields)
             .toString();
-    }
-
-    /**
-     * Checks if ticket relates to some Active (In progress/Patch Available) Contribution.
-     */
-    public boolean isActiveContribution() {
-        String status = status();
-
-        return Status.PA_NAME.equals(status)
-            || Status.IP_NAME.equals(status)
-            || Status.OPEN_NAME.equals(status)
-            || Status.BACKLOG_NAME.equals(status)
-            || Status.REOPENED_NAME.equals(status);
     }
 }


### PR DESCRIPTION
Fixed issue when bot didn't detect branches due to unmatched translated JIRA issue status.