### PR TITLE
Add option to disable auto-triggering bot during working hours

### DIFF
--- a/tcbot-common/src/main/java/org/apache/ignite/tcbot/common/conf/ITcServerConfig.java
+++ b/tcbot-common/src/main/java/org/apache/ignite/tcbot/common/conf/ITcServerConfig.java
@@ -16,6 +16,7 @@
  */
 package org.apache.ignite.tcbot.common.conf;
 
+import java.time.format.DateTimeFormatter;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import javax.annotation.Nullable;
@@ -72,4 +73,14 @@ public interface ITcServerConfig {
      * @return set of suite codes (build type IDs), failures in which should be threated as critical and notified.
      */
     @NonNull public Collection<String> trustedSuites();
+
+    /**
+     * @return Time as auto-triggering build is disabled. {@link DateTimeFormatter.ISO_LOCAL_TIME} must be used.
+     */
+    @Nullable String autoTriggeringBuildDisabledStartTime();
+
+    /**
+     * @return Time as auto-triggering build is enabled. {@link DateTimeFormatter.ISO_LOCAL_TIME} must be used.
+     */
+    @Nullable String autoTriggeringBuildDisabledEndTime();
 }

--- a/tcbot-engine/src/main/java/org/apache/ignite/tcbot/engine/conf/TcServerConfig.java
+++ b/tcbot-engine/src/main/java/org/apache/ignite/tcbot/engine/conf/TcServerConfig.java
@@ -17,6 +17,7 @@
 package org.apache.ignite.tcbot.engine.conf;
 
 import com.google.common.base.Strings;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -68,6 +69,12 @@ public class TcServerConfig implements ITcServerConfig {
 
     /** Additional service code to check access before allowing accessing this service. */
     private String additionalServiceToCheckAccess;
+
+    /** Time as auto-triggering build is disabled. {@link DateTimeFormatter.ISO_LOCAL_TIME} must be used. */
+    @Nullable private String autoTriggeringBuildDisabledStartTime;
+
+    /** Time as auto-triggering build is enabled. {@link DateTimeFormatter.ISO_LOCAL_TIME} must be used. */
+    @Nullable private String autoTriggeringBuildDisabledEndTime;
 
     public TcServerConfig() {
 
@@ -163,5 +170,15 @@ public class TcServerConfig implements ITcServerConfig {
         this.code = srvCode;
 
         return this;
+    }
+
+    /** {@inheritDoc} */
+    public String autoTriggeringBuildDisabledStartTime() {
+        return autoTriggeringBuildDisabledStartTime;
+    }
+
+    /** {@inheritDoc} */
+    public String autoTriggeringBuildDisabledEndTime() {
+        return autoTriggeringBuildDisabledEndTime;
     }
 }


### PR DESCRIPTION
It might be reasonable to not run nightly builds during working hours because it might slowing down development