### PR TITLE
IGNITE-24034 Update Ignite version in TeamCity bot to 2.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ allprojects {
 
         jettyVer = '9.4.12.v20180830'
 
-        ignVer = '2.14.0'
+        ignVer = '2.17.0'
 
         guavaVer = '26.0-jre'
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ allprojects {
 
         jettyVer = '9.4.12.v20180830'
 
-        ignVer = '2.17.0'
+        ignVer = '2.14.0'
 
         guavaVer = '26.0-jre'
 

--- a/conf/branches.json
+++ b/conf/branches.json
@@ -161,13 +161,13 @@
       "disableIssueTypes": []
     },
     {
-      "id": "ignite-2.11-nightly",
+      "id": "ignite-2.17-nightly",
       "chains": [
         {
           "serverId": "apache",
           "suiteId": "IgniteTests24Java8_RunAllNightly",
-          "branchForRest": "ignite-2.11",
-          "baseBranchForTc": "ignite-2.10",
+          "branchForRest": "ignite-2.17",
+          "baseBranchForTc": "ignite-2.16",
           "triggerBuild": true,
           //trigger twice per day
           "triggerBuildQuietPeriod": 720  //triggering quiet period in minutes,


### PR DESCRIPTION
With the availability of the 2.17 Ignite version, it is advised to update the version of Ignite from 2.16 to 2.17 in TeamCity bot.