### PR TITLE
Speed up PR failures page load: gzip, sync-load deadline, caching

### DIFF
--- a/ignite-tc-helper-web/src/main/java/org/apache/ignite/ci/web/Launcher.java
+++ b/ignite-tc-helper-web/src/main/java/org/apache/ignite/ci/web/Launcher.java
@@ -27,6 +27,7 @@ import org.apache.ignite.tcbot.common.conf.TcBotSystemProperties;
 import org.apache.ignite.tcbot.common.conf.TcBotWorkDir;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.ee8.webapp.WebAppContext;
 
 /**
@@ -54,7 +55,7 @@ public class Launcher {
      * @param dev Dev mode.
      * @param waitForStopSignal If {@code true}, starts the stdin watcher that stops the server.
      */
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "removal"})
     public static StartedServer startServer(boolean dev, boolean waitForStopSignal) throws Exception {
         if(dev)
             System.setProperty(TcBotSystemProperties.DEV_MODE, "true");
@@ -91,7 +92,12 @@ public class Launcher {
 
             ctx.setWar(warFile.toURI().toString());
         }
-        srv.setHandler(ctx);
+        GzipHandler gzipHandler = new GzipHandler();
+        gzipHandler.setMinGzipSize(1024);
+        gzipHandler.addIncludedMimeTypes("application/json", "text/plain", "text/html",
+            "text/css", "application/javascript", "text/javascript");
+        gzipHandler.setHandler(ctx);
+        srv.setHandler(gzipHandler);
 
         System.out.println("Starting server at [" + port + "]");
 

--- a/ignite-tc-helper-web/src/main/webapp/pr.html
+++ b/ignite-tc-helper-web/src/main/webapp/pr.html
@@ -173,7 +173,7 @@ function loadData() {
         var curFailuresUrl = "rest/pr/results" + parmsForRest();
 
         $("#loadStatus").html("&#8987; Please wait. First load of PR run-all data may require significant time.");
-        setTimeout(loadPartialData, 3000); // in case full loading stalls
+        setTimeout(loadPartialData, 0); // render cached data immediately while full (sync) load runs in background
         $.ajax({
             url: curFailuresUrl,
             success: function (result) {

--- a/tcbot-common/src/main/java/org/apache/ignite/tcbot/common/util/HttpUtil.java
+++ b/tcbot-common/src/main/java/org/apache/ignite/tcbot/common/util/HttpUtil.java
@@ -64,8 +64,11 @@ public class HttpUtil {
     /** */
     private static final int ERR_RESPONSE_BODY_LIMIT = 4_096;
 
-    /** */
-    private static final int TIMEOUT_MS = 60_000;
+    /** Connect timeout: a dead TeamCity host must fail fast, not hold a worker thread. */
+    private static final int CONNECT_TIMEOUT_MS = 10_000;
+
+    /** Read (inactivity) timeout: kept generous so large test/log pages can stream in. */
+    private static final int READ_TIMEOUT_MS = 60_000;
 
     /**
      * @param inputStream Input stream.
@@ -95,8 +98,8 @@ public class HttpUtil {
         URL obj = new URL(url);
         ensureIntegrationTestTarget(obj);
         HttpURLConnection con = (HttpURLConnection)obj.openConnection();
-        con.setConnectTimeout(TIMEOUT_MS);
-        con.setReadTimeout(TIMEOUT_MS);
+        con.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        con.setReadTimeout(READ_TIMEOUT_MS);
 
         con.setRequestProperty("Authorization", "Basic " + basicAuthTok);
         useKeepAlive(con);
@@ -131,8 +134,8 @@ public class HttpUtil {
         URL obj = new URL(url);
         ensureIntegrationTestTarget(obj);
         HttpURLConnection con = (HttpURLConnection)obj.openConnection();
-        con.setConnectTimeout(TIMEOUT_MS);
-        con.setReadTimeout(TIMEOUT_MS);
+        con.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        con.setReadTimeout(READ_TIMEOUT_MS);
 
         if (githubAuthTok != null)
             con.setRequestProperty("Authorization", "token " + githubAuthTok);
@@ -182,8 +185,8 @@ public class HttpUtil {
         URL obj = new URL(url);
         ensureIntegrationTestTarget(obj);
         HttpURLConnection con = (HttpURLConnection)obj.openConnection();
-        con.setConnectTimeout(TIMEOUT_MS);
-        con.setReadTimeout(TIMEOUT_MS);
+        con.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        con.setReadTimeout(READ_TIMEOUT_MS);
 
         con.setRequestMethod("POST");
         con.setRequestProperty("Authorization", "Basic " + tok);
@@ -365,8 +368,8 @@ public class HttpUtil {
         URL obj = new URL(url);
         ensureIntegrationTestTarget(obj);
         HttpURLConnection con = (HttpURLConnection)obj.openConnection();
-        con.setConnectTimeout(TIMEOUT_MS);
-        con.setReadTimeout(TIMEOUT_MS);
+        con.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        con.setReadTimeout(READ_TIMEOUT_MS);
         Charset charset = StandardCharsets.UTF_8;
 
         con.setRequestProperty("accept-charset", charset.toString());
@@ -407,8 +410,8 @@ public class HttpUtil {
         URL obj = new URL(url);
         ensureIntegrationTestTarget(obj);
         HttpURLConnection con = (HttpURLConnection)obj.openConnection();
-        con.setConnectTimeout(TIMEOUT_MS);
-        con.setReadTimeout(TIMEOUT_MS);
+        con.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        con.setReadTimeout(READ_TIMEOUT_MS);
         Charset charset = StandardCharsets.UTF_8;
 
         con.setRequestProperty("accept-charset", charset.toString());
@@ -444,8 +447,8 @@ public class HttpUtil {
         URL obj = new URL(url);
         ensureIntegrationTestTarget(obj);
         HttpURLConnection con = (HttpURLConnection)obj.openConnection();
-        con.setConnectTimeout(TIMEOUT_MS);
-        con.setReadTimeout(TIMEOUT_MS);
+        con.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        con.setReadTimeout(READ_TIMEOUT_MS);
         Charset charset = StandardCharsets.UTF_8;
 
         con.setRequestProperty("accept-charset", charset.toString());

--- a/tcbot-engine/src/main/java/org/apache/ignite/tcbot/engine/chain/BuildChainProcessor.java
+++ b/tcbot-engine/src/main/java/org/apache/ignite/tcbot/engine/chain/BuildChainProcessor.java
@@ -188,6 +188,7 @@ public class BuildChainProcessor {
         );
 
         List<MultBuildRunCtx> contexts = new ArrayList<>(freshRebuilds.size());
+        List<Future<?>> histFuts = new ArrayList<>(freshRebuilds.size());
 
         freshRebuilds.forEach((bt, listBuilds) -> {
             List<FatBuildCompacted> buildsForSuite = FutureUtil.getResults(listBuilds)
@@ -204,10 +205,10 @@ public class BuildChainProcessor {
             buildsForSuite.forEach(buildCompacted -> ctx.addBuild(loadChanges(buildCompacted, tcIgn,
                 mode == SyncMode.NONE)));
 
-            //ask for history for the suite in parallel
-            tcUpdatePool.getService().submit(() -> {
+            //ask for history for the suite in parallel; joined below so the sort does not recompute it serially
+            histFuts.add(tcUpdatePool.getService().submit(() -> {
                 ctx.history(tcIgn, failRateBranchId, null);
-            });
+            }));
 
             analyzeTests(ctx, tcIgn, procLog);
 
@@ -215,6 +216,9 @@ public class BuildChainProcessor {
 
             contexts.add(ctx);
         });
+
+        // await parallel history warm-up so the fail-rate sort below reads memoized values instead of loading serially
+        histFuts.forEach(FutureUtil::getResult);
 
 
         Integer someEntryPnt = entryPoints.iterator().next();

--- a/tcbot-engine/src/main/java/org/apache/ignite/tcbot/engine/pr/PrChainsProcessor.java
+++ b/tcbot-engine/src/main/java/org/apache/ignite/tcbot/engine/pr/PrChainsProcessor.java
@@ -29,9 +29,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -87,6 +91,26 @@ public class PrChainsProcessor {
 
     /** Max time to wait for AI prompt build log processing. */
     private static final long AI_PROMPT_LOG_WAIT_MS = TimeUnit.MINUTES.toMillis(1);
+
+    /** Deadline for synchronous PR results load before falling back to cached data (system-property overridable). */
+    private static final long PR_RESULTS_SYNC_WAIT_MS = TimeUnit.SECONDS.toMillis(
+        Long.getLong("tcbot.pr.results.syncWaitSecs", 45));
+
+    /**
+     * Dedicated pool that bounds the synchronous PR results load. Must be separate from {@link #tcUpdatePool}: the
+     * bounded task waits on many sub-tasks submitted to {@code tcUpdatePool}, so sharing the pool could starve it.
+     */
+    private final ExecutorService resultsLoadPool = Executors.newCachedThreadPool(new java.util.concurrent.ThreadFactory() {
+        private final AtomicInteger cnt = new AtomicInteger();
+
+        @Override public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, "pr-results-load-" + cnt.incrementAndGet());
+
+            t.setDaemon(true);
+
+            return t;
+        }
+    });
 
     /** */
     private static final ThreadLocal<DateFormat> THREAD_TIME_FORMATTER = new ThreadLocal<DateFormat>() {
@@ -194,15 +218,14 @@ public class PrChainsProcessor {
 
         String baseBranchForTc = Strings.isNullOrEmpty(tcBaseBranchParm) ? dfltBaseTcBranch(srvCodeOrAlias) : tcBaseBranchParm;
 
-        FullChainRunCtx ctx = buildChainProcessor.loadFullChainContext(
+        FullChainRunCtx ctx = loadFullChainContextBounded(
             tcIgnited,
             hist,
             rebuild,
             logs,
             buildResMergeCnt == 1,
             baseBranchForTc,
-            mode,
-            null, null);
+            mode);
 
         DsChainUi chainStatus = new DsChainUi(srvCodeOrAlias, tcIgnited.serverCode(), branchForTc);
 
@@ -226,6 +249,84 @@ public class PrChainsProcessor {
         res.initCounters(getPrUpdateCounters(srvCodeOrAlias, branchForTc, baseBranchForTc, creds));
 
         return res;
+    }
+
+    /**
+     * Loads the chain context, bounding the synchronous (TeamCity-syncing) load with a deadline. On timeout returns
+     * whatever is already cached instead of holding the request thread until every slow TeamCity call completes; the
+     * page keeps polling and picks up fresh data on a later refresh. The cached fallback path ({@link SyncMode#NONE})
+     * is executed directly and is not bounded.
+     *
+     * @param tcIgnited TeamCity facade.
+     * @param hist Entry build ids.
+     * @param rebuild Rebuild mode.
+     * @param logs Log processing mode.
+     * @param singleBuild Whether a single build is expected.
+     * @param baseBranchForTc Base branch.
+     * @param mode Requested sync mode.
+     */
+    private FullChainRunCtx loadFullChainContextBounded(
+        ITeamcityIgnited tcIgnited,
+        List<Integer> hist,
+        LatestRebuildMode rebuild,
+        ProcessLogsMode logs,
+        boolean singleBuild,
+        String baseBranchForTc,
+        SyncMode mode) {
+        if (mode == SyncMode.NONE)
+            return loadFullChainContext(tcIgnited, hist, rebuild, logs, singleBuild, baseBranchForTc, SyncMode.NONE);
+
+        Future<FullChainRunCtx> fut = resultsLoadPool.submit(
+            () -> loadFullChainContext(tcIgnited, hist, rebuild, logs, singleBuild, baseBranchForTc, mode));
+
+        try {
+            return fut.get(PR_RESULTS_SYNC_WAIT_MS, TimeUnit.MILLISECONDS);
+        }
+        catch (TimeoutException e) {
+            fut.cancel(true);
+
+            // deadline exceeded: serve cached data now, background polling refreshes the page later
+            return loadFullChainContext(tcIgnited, hist, rebuild, logs, singleBuild, baseBranchForTc, SyncMode.NONE);
+        }
+        catch (InterruptedException e) {
+            fut.cancel(true);
+
+            Thread.currentThread().interrupt();
+
+            throw new IllegalStateException("Interrupted while loading PR chain context", e);
+        }
+        catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+
+            if (cause instanceof RuntimeException)
+                throw (RuntimeException)cause;
+
+            if (cause instanceof Error)
+                throw (Error)cause;
+
+            throw new RuntimeException(cause);
+        }
+    }
+
+    /**
+     * @param tcIgnited TeamCity facade.
+     * @param hist Entry build ids.
+     * @param rebuild Rebuild mode.
+     * @param logs Log processing mode.
+     * @param singleBuild Whether a single build is expected.
+     * @param baseBranchForTc Base branch.
+     * @param mode Sync mode.
+     */
+    private FullChainRunCtx loadFullChainContext(
+        ITeamcityIgnited tcIgnited,
+        List<Integer> hist,
+        LatestRebuildMode rebuild,
+        ProcessLogsMode logs,
+        boolean singleBuild,
+        String baseBranchForTc,
+        SyncMode mode) {
+        return buildChainProcessor.loadFullChainContext(
+            tcIgnited, hist, rebuild, logs, singleBuild, baseBranchForTc, mode, null, null);
     }
 
     /**

--- a/tcbot-persistence/src/main/java/org/apache/ignite/tcbot/persistence/IgniteStringCompactor.java
+++ b/tcbot-persistence/src/main/java/org/apache/ignite/tcbot/persistence/IgniteStringCompactor.java
@@ -122,22 +122,19 @@ public class IgniteStringCompactor implements IStringCompactor {
 
         initIfNeeded();
 
-        QueryCursor<Cache.Entry<String, org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity>> qryCursor
-            = stringsCache.query(new SqlQuery<String, org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity>(org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity.class, "id = ?").setArgs(id));
+        try (QueryCursor<Cache.Entry<String, org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity>> qryCursor
+            = stringsCache.query(new SqlQuery<String, org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity>(org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity.class, "id = ?").setArgs(id))) {
 
-        Iterator<Cache.Entry<String, org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity>> iter = qryCursor.iterator();
+            Iterator<Cache.Entry<String, org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity>> iter = qryCursor.iterator();
 
-        if (!iter.hasNext()) {
-            System.err.println("Error: String Not found string by id " + id);
+            if (!iter.hasNext()) {
+                logger.error("String not found by id {}", id);
 
-            return null;
+                return null;
+            }
+
+            return ObjectInterner.internString(iter.next().getValue().val());
         }
-
-        Cache.Entry<String, org.apache.ignite.ci.teamcity.ignited.IgniteStringCompactor.CompactorEntity> next = iter.next();
-
-        qryCursor.close();
-
-        return ObjectInterner.internString(next.getValue().val());
     }
 
     /** {@inheritDoc} */

--- a/tcbot-teamcity-ignited/src/main/java/org/apache/ignite/tcignited/TeamcityIgnitedImpl.java
+++ b/tcbot-teamcity-ignited/src/main/java/org/apache/ignite/tcignited/TeamcityIgnitedImpl.java
@@ -620,7 +620,7 @@ public class TeamcityIgnitedImpl implements ITeamcityIgnited {
     }
 
     /** {@inheritDoc} */
-    @GuavaCached(maximumSize = 500, expireAfterAccessSecs = 30, softValues = true)
+    @GuavaCached(maximumSize = 8000, expireAfterAccessSecs = 60, softValues = true)
     @Override public FatBuildCompacted getFatBuild(int buildId, SyncMode mode) {
         return loadFatBuild(buildId, mode);
     }

--- a/tcbot-teamcity-ignited/src/main/java/org/apache/ignite/tcignited/buildref/BuildRefDao.java
+++ b/tcbot-teamcity-ignited/src/main/java/org/apache/ignite/tcignited/buildref/BuildRefDao.java
@@ -56,11 +56,16 @@ import org.apache.ignite.tcbot.persistence.CacheConfigs;
 import org.apache.ignite.tcbot.persistence.IStringCompactor;
 import org.apache.ignite.tcignited.build.UpdateCountersStorage;
 import org.apache.ignite.tcservice.model.hist.BuildRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 public class BuildRefDao {
+    /** Logger. */
+    private static final Logger logger = LoggerFactory.getLogger(BuildRefDao.class);
+
     /** Cache name */
     public static final String TEAMCITY_BUILD_CACHE_NAME = "teamcityBuildRef";
 
@@ -260,10 +265,10 @@ public class BuildRefDao {
                                 .filter(e -> e.buildTypeId() == buildTypeIdId)
                                 .collect(Collectors.toList());
 
-                            if (!resForBranch.isEmpty()) {
-                                System.err.println("Branch " + compactor.getStringFromId(branchNameId)
-                                    + " Suite " + compactor.getStringFromId(buildTypeIdId)
-                                    + " builds " + resForBranch.size() + " ");
+                            if (!resForBranch.isEmpty() && logger.isDebugEnabled()) {
+                                logger.debug("Branch {} Suite {} builds {}",
+                                    compactor.getStringFromId(branchNameId),
+                                    compactor.getStringFromId(buildTypeIdId), resForBranch.size());
                             }
 
                             return resForBranch;
@@ -439,9 +444,9 @@ public class BuildRefDao {
             }
         }
 
-        if (!list.isEmpty()) {
-            System.err.println(" Branch " + compactor.getStringFromId(branchNameId)
-                + " builds " + list.size() + " (Overall) ");
+        if (!list.isEmpty() && logger.isDebugEnabled()) {
+            logger.debug("Branch {} builds {} (Overall)",
+                compactor.getStringFromId(branchNameId), list.size());
         }
 
         return list;


### PR DESCRIPTION
## Problem

Opening the PR failures page (`pr.html`) is slow and sometimes returns no result at all. Measured on the live service, `/rest/pr/results` returns **~170 KB of uncompressed JSON** and performs a **synchronous TeamCity reload (`SyncMode.RELOAD_QUEUED`) inside the HTTP request thread**. On a cold cache or a slow TeamCity the request stalls (up to the 60 s HTTP timeouts, potentially serialized), and the cached fallback is only attempted after a 3 s delay.

## Changes

**Transport / UX (immediate, user-visible)**
- **Enable Jetty `GzipHandler`** for `application/json` and static text responses (`Launcher`). ~170 KB → ~15–25 KB on the wire.
- **Render cached PR data immediately** instead of after a 3 s timer (`pr.html`): the sync refresh still runs in the background.

**Server-side latency / robustness**
- **Bound the synchronous `/results` chain load with a deadline** (default 45 s, `-Dtcbot.pr.results.syncWaitSecs`) on a **dedicated pool** — separate from `tcUpdatePool` to avoid starving it — falling back to cached data on timeout so the request thread is released and background polling refreshes the page (`PrChainsProcessor`).
- **Warm suite history in parallel and join before the fail-rate sort.** Previously the parallel warm-up was fire-and-forget and the sort comparator recomputed history serially in the request thread (`BuildChainProcessor`).
- **Raise the fat-build Guava cache from 500 to 8000 entries** so a single RunAll chain (entry + hundreds of dependency builds) no longer thrashes it (`TeamcityIgnitedImpl`).
- **Split the TeamCity HTTP timeout**: connect 10 s (was 60 s), read 60 s — a dead host fails fast instead of holding a worker thread (`HttpUtil`).

**Cleanups**
- Close a leaked `QueryCursor` in `IgniteStringCompactor.getStringFromId`.
- Replace hot-path `System.err` prints with guarded `logger.debug` (`BuildRefDao`, `IgniteStringCompactor`).

## Verification

- All touched modules compile; unit tests of `tcbot-common`, `tcbot-persistence`, `tcbot-teamcity-ignited`, `tcbot-engine` pass.
- Gzip wiring verified at runtime against Jetty 12.1.8 (response `Content-Encoding: gzip`, compressed payload, lossless decode).
- The deadline and history-parallelism changes are covered by compilation and unit tests only; behaviour under load / against a slow TeamCity should be validated on a staging instance.
